### PR TITLE
既存APIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -12,7 +12,6 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   def create
      # ログインユーザーと紐付いた記事が作成できる。
     article = current_user.articles.create!(article_params)
-
     # jsonとして値を返す
     render json: article  #each_serializer: Api::V1::ArticleSerializerはいらない？
   end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,6 +1,10 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
  private
  def sign_up_params
-   params.permit(:name, :email, :password)
+   params.permit(:name, :email, :password, :password_confirmation)
+ end
+
+ def sign_in_params
+   params.permit(:email, :password)
  end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,7 +1,12 @@
 class Api::V1::BaseApiController < ApplicationController
-
-  def current_user
-    # テーブルの最初のユーザーを入れる
-    @current_user ||= User.first
-  end
+  # include DeviseTokenAuth::Concerns::SetUserByToken
+  before_action :authenticate_user!, except:
+  [:index, :show]
+  #ダミーメソッドだったので削除
+  # def current_user
+  #   @current_user ||= User.first
+  # end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe User, type: :model do
     let(:user){build(:user)}
     it "ユーザー登録ができる" do
     expect(user).to be_valid
-    binding.pry
     end
   end
   context "nameを入力していないとき" do

--- a/spec/requests/api/v1/articles_request_spec.rb
+++ b/spec/requests/api/v1/articles_request_spec.rb
@@ -32,13 +32,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
     end
   end
   describe "POST/api/v1/articles" do
-    subject{post(api_v1_articles_path,params:params)}
+    subject{post(api_v1_articles_path,params:params,headers:headers)}
   context "ユーザーがログインしているとき" do
-    # let!(:user){create(:user)}
-    # let(:current_user){User.first}
     let(:current_user){create(:user)}
     let(:params){{article:attributes_for(:article)}}
-    before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
+    # before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
+    let(:headers){current_user.create_new_auth_token }
   it "記事が作られる" do
     expect{subject}.to change {Article.count}.by(1)
     res = JSON.parse(response.body)
@@ -48,14 +47,15 @@ RSpec.describe "Api::V1::Articles", type: :request do
    end
   end
   describe "PATCH/api/v1/articles:id" do
-   subject{patch(api_v1_article_path(article_id),params:params)}
+   subject{patch(api_v1_article_path(article_id),params:params,headers:headers)}
 
    context "適切なパラメーターが送られたとき" do
      let!(:article){create(:article)}
      let(:article_id){article.id}
      let(:current_user){article.user}
      let(:params){{article:{title:"update_title",body:"update_body"}}}
-     before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
+    #  before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
+     let(:headers){current_user.create_new_auth_token }
     #  let(:params){{attributes_for(:article)}}
      it "記事が上書きされる" do
        expect{subject}.to change {Article.find(article_id).title}.from(article.title).to("update_title") &
@@ -67,13 +67,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
    end
   end
   describe "DELETE/api/v1/articles:id" do
-    subject{delete(api_v1_article_path(article_id))}
+    subject{delete(api_v1_article_path(article_id),headers:headers)}
 
     context "適切なパラメーターが送られたとき" do
       let(:current_user){article.user}
       let!(:article){create(:article)}
       let(:article_id){article.id}
       # before{allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user)}
+      let(:headers){current_user.create_new_auth_token }
       it "記事が削除される" do
         expect{subject}.to change {Article.count}.by(-1)
       end

--- a/spec/requests/api/v1/auth/registrations_request_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
     subject{post(api_v1_user_registration_path,params:params)}
     context "name,email,passwordが送られたとき" do
     let(:params){attributes_for(:user)}
-    fit "ユーザーが登録される" do
+    it "ユーザーが登録される" do
       subject
       res = JSON.parse(response.body)
       expect(res.values[0]).to eq "success"

--- a/spec/requests/api/v1/auth/sessions_request_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_request_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+  describe "POST/api/v1/auth/sign_in" do
+    subject{post(api_v1_user_session_path,params:params)}
+  context "emailとpasswordが入力されたとき" do
+  #データベースにユーザー情報が登録されている状態をつくる
+  let!(:user){create(:user)}
+  #データベースに登録されているユーザーのemail,password
+  let(:params){{email:email,password:password}}
+  let(:email){user.email}
+  let(:password){user.password}
+
+  it "ログインできる" do
+    subject
+    res = response.headers
+    expect(res["uid"]).to be_present
+    expect(res["access-token"]).to be_present
+    expect(res["client"]).to be_present
+    expect(response.status).to eq 200
+
+  end
+  end
+  context "emailが正しくない場合" do
+    let!(:user){create(:user)}
+    let(:params){{email:email,password:password}}
+    let(:email){""}
+    let(:password){user.password}
+
+  it "ログインできない" do
+    subject
+    res = JSON.parse(response.body)
+    expect(res["success"]).to eq false
+    expect(res["errors"]).to include("Invalid login credentials. Please try again.")
+    expect(response.headers["uid"]).to be_blank
+    expect(response.headers["access-token"]).to be_blank
+    expect(response.headers["client"]).to be_blank
+
+  end
+  end
+  context "passwordが正しくない場合" do
+    let!(:user){create(:user)}
+    let(:params){{email:email,password:password}}
+    let(:email){user.email}
+    let(:password){""}
+    it "ログインできない" do
+      subject
+    res = JSON.parse(response.body)
+    expect(res["success"]).to eq false
+    expect(res["errors"]).to include("Invalid login credentials. Please try again.")
+    expect(response.headers["uid"]).to be_blank
+    expect(response.headers["access-token"]).to be_blank
+    expect(response.headers["client"]).to be_blank
+    end
+  end
+  describe "POST/api/v1/auth/sign_out" do
+    subject{delete(destroy_api_v1_user_session_path,headers:headers)}
+    context "ログアウトしたとき" do
+      let(:user){create(:user)}
+      let(:headers){user.create_new_auth_token}
+
+    it "ログアウトできる" do
+      subject
+      expect(user.reload.tokens).to be_blank
+      expect(response.status).to eq 200
+    end
+    end
+  end
+  end
+end


### PR DESCRIPTION
・ダミーメソッドのcurrent_userを削除
・スタブを削除
・devise_token_authで提供されているcurrent_userを使えるように実装
・ authenticate_user!を実装
・ログインが必要な API を叩く際に headers を渡すように実装
